### PR TITLE
Allow passing parameters of type long when an int is expected.

### DIFF
--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -62,6 +62,8 @@ class TypeChecker(object):
 
 
     def check_int(self, value):
+        if isinstance(value, long):
+            return True, value
         return isinstance(value, int), value
 
     

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -157,6 +157,11 @@ class CoreTests(Test):
         self.assertEqual(self.last_query()['limit'], ['5'])
 
 
+    def test_parameter_type_long(self):
+        self.api.testMethod(test_id=1L, limit=5L)
+        self.assertEqual(self.last_query()['limit'], ['5'])
+
+
     def bad_value_msg(self, name, t, v):
         return "Bad value for parameter %s of type '%s' - %s" % (name, t, v)
 


### PR DESCRIPTION
Two commits.

The first commit adds a test that illustrates that longs cause an exception when an int is expected. The other commit fixes the issue and makes the test pass.
