### PR TITLE
Replace 'print' statement with call to logger

### DIFF
--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -299,7 +299,7 @@ class API(object):
         
 
     def _get_url(self, url, http_method, content_type, body):
-        print "_get_url: url = %r" % url
+        self.log("API._get_url: url = %r" % url)
         with closing(urllib2.urlopen(url)) as f:
             return f.read() 
   


### PR DESCRIPTION
Simple fix for what looks like a simple mistake.
