### PR TITLE
Bugfix: Only use OAuth client if it's actually set

### DIFF
--- a/etsy/_v2.py
+++ b/etsy/_v2.py
@@ -14,6 +14,7 @@ class EtsyV2(API):
     def __init__(self, api_key='', key_file=None, method_cache=missing, 
                  etsy_env=EtsyEnvSandbox(), log=None, etsy_oauth_client=None):
         self.api_url = etsy_env.public_api_url
+        self.etsy_oauth_client = None
 
         if etsy_oauth_client:
             self.api_url = etsy_env.private_api_url
@@ -22,5 +23,6 @@ class EtsyV2(API):
         super(EtsyV2, self).__init__(api_key, key_file, method_cache, log)
 
     def _get_url(self, url, http_method, content_type, body):
-        return self.etsy_oauth_client.do_oauth_request(url, http_method, content_type, body)
-  
+        if self.etsy_oauth_client is not None:
+            return self.etsy_oauth_client.do_oauth_request(url, http_method, content_type, body)
+        return API._get_url(self, url, http_method, content_type, body)


### PR DESCRIPTION
Fixes the API crashing on the first call if the `etsy_oath_client` parameter wasn't passed to the constructor.
