### PR TITLE
Add support for selecting specific fields of Etsy resources, and requesting associations

### DIFF
--- a/etsy/__init__.py
+++ b/etsy/__init__.py
@@ -1,4 +1,4 @@
-from _v2 import EtsyV2 as Etsy
+from _v2 import Association, EtsyV2 as Etsy
 from etsy_env import EtsyEnvSandbox, EtsyEnvProduction
 
 

--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -141,10 +141,16 @@ class APIMethod(object):
             ps[p] = kwargs[p]
             del kwargs[p]
 
+        fields = kwargs.pop('fields', None)
+        includes = kwargs.pop('includes', None)
+
         self.type_checker(self.spec, **kwargs)
+
+        if fields:
+            kwargs['fields'] = ','.join(fields)
+        if includes:
+            kwargs['includes'] = ','.join([str(include) for include in includes])
         return self.api._get(self.spec['http_method'], self.uri_format % ps, **kwargs)
-
-
 
 
 class MethodTableCache(object):

--- a/etsy/_v2.py
+++ b/etsy/_v2.py
@@ -24,3 +24,31 @@ class EtsyV2(API):
         if self.etsy_oauth_client is not None:
             return self.etsy_oauth_client.do_oauth_request(url, http_method, content_type, body)
         return API._get_url(self, url, http_method, content_type, body)
+
+
+class Association(object):
+    class Bounds(object):
+        def __init__(self, limit, offset=None):
+            self.limit = limit
+            self.offset = offset
+
+    def __init__(self, name, fields=None, scope=None, bounds=None, child=None):
+        self.name = name
+        self.fields = fields
+        self.scope = scope
+        self.bounds = bounds
+        self.child = child
+
+    def __str__(self):
+        elems = [self.name]
+        if self.fields is not None:
+            elems.extend(['(', ','.join(self.fields), ')'])
+        if self.scope is not None:
+            elems.extend([':', self.scope])
+        if self.bounds is not None:
+            elems.extend([':', str(self.bounds.limit)])
+            if self.bounds.offset is not None:
+                elems.extend([':', str(self.bounds.offset)])
+        if self.child is not None:
+            elems.extend(['/', str(self.child)])
+        return ''.join(elems)


### PR DESCRIPTION
`Association` is a bit of a long name, but there isn't an immediately apparent way to shorten it. Making `Bounds` an inner class of `Association` doesn't help matters, but it doesn't make sense when top-level.

The serialization method uses the `''.join(list)` trick to speed up serialization (ostensibly) by an order of magnitude, but this may be a premature optimization.
