### PR TITLE
Oauth library doesn't like it when you set request body to None

### DIFF
--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -309,7 +309,7 @@ class API(object):
 
         if http_method == 'GET':
             url = '%s%s?%s' % (self.api_url, url, urlencode(kwargs))
-            body = None
+            body = ''
             content_type = None
         elif http_method == 'POST':
             url = '%s%s' % (self.api_url, url)


### PR DESCRIPTION
When I run the test_v2.py file I get the traceback pasted below. The oauth2 library doesn't handle a request body of None very well. The following pull request fixes this issue by setting the request body to an empty string rather than None.

```
Creating v2 Etsy API, base url=http://openapi.etsy.com/v2.
Not using cached method table.
Traceback (most recent call last):
  File "./test_v2.py", line 51, in <module>
    etsy_api = Etsy(config.api_key, etsy_oauth_client=oauth_client, etsy_env=etsy_env, log=my_log)
  File "/usr/local/lib/python2.7/dist-packages/etsy/_v2.py", line 21, in __init__
    super(EtsyV2, self).__init__(api_key, key_file, method_cache, log)
  File "/usr/local/lib/python2.7/dist-packages/etsy/_core.py", line 262, in __init__
    self._get_methods(method_cache)
  File "/usr/local/lib/python2.7/dist-packages/etsy/_core.py", line 272, in _get_methods
    ms = self.method_cache.get()
  File "/usr/local/lib/python2.7/dist-packages/etsy/_core.py", line 179, in get
    ms = self.api.get_method_table()
  File "/usr/local/lib/python2.7/dist-packages/etsy/_core.py", line 286, in get_method_table
    return self._get('GET', '/')
  File "/usr/local/lib/python2.7/dist-packages/etsy/_core.py", line 328, in _get
    data = self._get_url(url, http_method, content_type, body)
  File "/usr/local/lib/python2.7/dist-packages/etsy/_v2.py", line 25, in _get_url
    return self.etsy_oauth_client.do_oauth_request(url, http_method, content_type, body)
  File "/usr/local/lib/python2.7/dist-packages/etsy/oauth.py", line 43, in do_oauth_request
    resp, content = self.request(url, http_method, body=body)
  File "/usr/local/lib/python2.7/dist-packages/oauth2/__init__.py", line 662, in request
    req.sign_request(self.method, self.consumer, self.token)
  File "/usr/local/lib/python2.7/dist-packages/oauth2/__init__.py", line 493, in sign_request
    self['oauth_body_hash'] = base64.b64encode(sha(self.body).digest())
TypeError: must be string or buffer, not None
```
