### PR TITLE
Don't use api key if doing an oauth request

### DIFF
--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -309,7 +309,7 @@ class API(object):
 
         if http_method == 'GET':
             url = '%s%s?%s' % (self.api_url, url, urlencode(kwargs))
-            body = None
+            body = ''
             content_type = None
         elif http_method == 'POST':
             url = '%s%s' % (self.api_url, url)

--- a/etsy/_core.py
+++ b/etsy/_core.py
@@ -305,7 +305,8 @@ class API(object):
   
 
     def _get(self, http_method, url, **kwargs):
-        kwargs.update(dict(api_key=self.api_key))
+        if self.etsy_oauth_client is None:
+            kwargs.update(dict(api_key=self.api_key))
 
         if http_method == 'GET':
             url = '%s%s?%s' % (self.api_url, url, urlencode(kwargs))


### PR DESCRIPTION
Whenever an api key is used when constructing a request the oauth credentials seemed to be ignored. For example, when doing a request with a "**SELF**" as user id, I always get this response from etsy:

```
No logged in user; please specify a user id instead
```

This pull request fixes it by not using the api key if oauth specified. Also contains fix for #10 .
